### PR TITLE
Disable tagging of published version in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,6 +87,7 @@ jobs:
             if: github.ref != 'refs/heads/master'
                 
           - name: Tag published version
+            if: false
             uses: restackio/update-json-file-action@2.1
             with:
               file: ./publish/appsettings.json


### PR DESCRIPTION
Prevent tagging of the published version during the build process by disabling the related action.