### PR TITLE
Update Docker image tagging to use variable for Docker Hub account ID

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -237,7 +237,7 @@ jobs:
 
         - name: Tag Docker image as Latest
           run: |
-              docker tag ${{ github.repository }}:${{ env.version }} ${{ github.repository }}:latest
+              docker tag ${{ vars.DOCKERHUB_ACCOUNT_ID }}/minha-app3:${{ env.version }} ${{ vars.DOCKERHUB_ACCOUNT_ID }}/minha-app3:latest
           if: github.ref == 'refs/heads/master'
 
         - name: Login to Docker Hub


### PR DESCRIPTION
Refactor the Docker image tagging process to utilize a variable for the Docker Hub account ID, enhancing flexibility and maintainability.